### PR TITLE
Fix state attributes

### DIFF
--- a/custom_components/tauron_amiplus/sensor.py
+++ b/custom_components/tauron_amiplus/sensor.py
@@ -99,7 +99,7 @@ class TauronAmiplusSensor(SensorEntity, CoordinatorEntity[TauronAmiplusRawData])
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         _params = {
             "tariff": self.tariff,
             "zones_updated": self.power_zones_last_update,


### PR DESCRIPTION
Seems that the device_state_attributes method was replaced with extra_state_attributes. Now the extra attributes are actually available in Home Assistant.