### PR TITLE
Zmiana sposobu pobierania danych

### DIFF
--- a/custom_components/tauron_amiplus/connector.py
+++ b/custom_components/tauron_amiplus/connector.py
@@ -340,7 +340,7 @@ class TauronAmiplusConnector:
         dnc = datetime.datetime.now() - datetime.timedelta(days=1)
         if values is not None and not any(a is None for a in values['data']['values']):
             self.add_all_data(values, day)
-            if (day.date() < dnc.date()):
+            if day.date() < dnc.date():
                 self._cache.add_value(day, generation, values)
             self.log(f"Downloaded daily data for day: {day_str}, generation: {generation}")
             return values


### PR DESCRIPTION
Fixes #218 

Wersja działająca na dzień dzisiejszy. Zmiany obejmują pobieranie danych wyłącznie do dnia poprzedzającego dzień dzisiejszy oraz niedodawanie danych do cache dla dnia poprzedzającego. Aktualnie dane z licznika pojawiają się wcześniej (nad ranem), ale mogą być niekompletne. Kolejny przebieg pobierze brakujące dane. W tym momencie nie widzę opcji rozpoznawania niekompletnego zestawu danych (oryginalny JavaScript elicznika też tego nie potrafi). Co będzie jutro, czas pokaże.