### PR TITLE
Tariff regex adjusted

### DIFF
--- a/custom_components/tauron_amiplus/connector.py
+++ b/custom_components/tauron_amiplus/connector.py
@@ -271,7 +271,7 @@ class TauronAmiplusConnector:
         self.log(f"Selecting meter: {self._meter_id}")
         select_response = await self._session.request("POST", CONST_URL_SELECT_METER, data=payload_select_meter, headers=CONST_REQUEST_HEADERS)
         select_response_text = await select_response.text()
-        tariff_search = re.findall(r"'Tariff' : '(.*)',", select_response_text)
+        tariff_search = re.findall(r"[^_]Tariff: '(.*)',", select_response_text)
         if len(tariff_search) > 0:
             tariff = tariff_search[0]
             return tariff


### PR DESCRIPTION
Since tariff started to show as 'unknown', I've found simple regex adjustment to make it work again.

I've checked it internally on various values (G11, G12, G12W, some random strings), but I'm not sure if source (Tauron) returns tariff in the same way for contracts other than mine (G12W).
