### PR TITLE
Fix Tauron sensor crashes on missing readings and preserve zone names

### DIFF
--- a/custom_components/tauron_amiplus/connector.py
+++ b/custom_components/tauron_amiplus/connector.py
@@ -366,14 +366,15 @@ class TauronAmiplusConnector:
         data = {"data": {
             "allData": [],
             "sum": 0,
-            "zones": {}
+            "zones": {},
+            "zonesName": {},
         }}
         for day in [day_from + datetime.timedelta(days=x) for x in range((day_to - day_from).days + 1)]:
             day_data = await self.get_raw_values_daily_for_day(day, generation)
             if day_data is not None:
                 data["data"]["allData"].extend(day_data["data"]["allData"])
                 data["data"]["sum"] += day_data["data"]["sum"]
-                data["data"]["zonesName"] = day_data["data"]["zonesName"]
+                data["data"]["zonesName"].update(day_data["data"].get("zonesName", {}))
                 if "tariff" in day_data["data"]:
                     data["data"]["tariff"] = day_data["data"]["tariff"]
                 for z, v in day_data["data"]["zones"].items():

--- a/custom_components/tauron_amiplus/sensor.py
+++ b/custom_components/tauron_amiplus/sensor.py
@@ -237,6 +237,26 @@ class TauronAmiplusSensor(SensorEntity, CoordinatorEntity):
         return total, zones, data_range
 
     @staticmethod
+    def _safe_float(value, default: float = 0.0) -> float:
+        if value is None:
+            return default
+        try:
+            if isinstance(value, str):
+                value = value.strip()
+                if value == "":
+                    return default
+                value = value.replace(",", ".")
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _get_zone_name(zone_names, zone_id):
+        zone_id = str(zone_id)
+        normalized_zone_names = {str(key): value for key, value in zone_names.items()}
+        return normalized_zone_names.get(zone_id, zone_id)
+
+    @staticmethod
     def get_balanced_data(consumption_data_json, generation_data_json):
         zone_names = consumption_data_json["data"]["zonesName"]
         consumption_data = consumption_data_json["data"]["allData"]
@@ -250,9 +270,9 @@ class TauronAmiplusSensor(SensorEntity, CoordinatorEntity):
         zones = {}
 
         for consumption, generation in zip(consumption_data, generation_data):
-            value_consumption = float(consumption["EC"])
-            value_generation = float(generation["EC"])
-            zone = zone_names[consumption["Zone"]]
+            value_consumption = TauronAmiplusSensor._safe_float(consumption.get("EC"))
+            value_generation = TauronAmiplusSensor._safe_float(generation.get("EC"))
+            zone = TauronAmiplusSensor._get_zone_name(zone_names, consumption.get("Zone"))
             balance = value_consumption - value_generation
             if balance > 0:
                 sum_consumption += balance

--- a/custom_components/tauron_amiplus/statistics.py
+++ b/custom_components/tauron_amiplus/statistics.py
@@ -162,6 +162,20 @@ class TauronAmiplusStatisticsUpdater:
         return (as_utc(now) - last_stats_end).days < 30
 
     @staticmethod
+    def _safe_float(value, default: float = 0.0) -> float:
+        if value is None:
+            return default
+        try:
+            if isinstance(value, str):
+                value = value.strip()
+                if value == "":
+                    return default
+                value = value.replace(",", ".")
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
     def prepare_balanced_raw_data(raw_data) -> (dict, dict):
         consumption_data = raw_data[CONST_CONSUMPTION]
         generation_data = raw_data[CONST_GENERATION]
@@ -171,8 +185,8 @@ class TauronAmiplusStatisticsUpdater:
         balanced_generation = []
 
         for consumption, generation in zip(consumption_data, generation_data):
-            value_consumption = float(consumption["EC"])
-            value_generation = float(generation["EC"])
+            value_consumption = TauronAmiplusStatisticsUpdater._safe_float(consumption.get("EC"))
+            value_generation = TauronAmiplusStatisticsUpdater._safe_float(generation.get("EC"))
             balance = value_consumption - value_generation
             if balance > 0:
                 output_consumption = {

--- a/custom_components/tauron_amiplus/statistics.py
+++ b/custom_components/tauron_amiplus/statistics.py
@@ -236,7 +236,7 @@ class TauronAmiplusStatisticsUpdater:
             start = self.get_time(raw_hour)
             if last_stats_time is not None and start <= last_stats_time:
                 continue
-            usage = float(raw_hour["EC"])
+            usage = self._safe_float(raw_hour.get("EC"))
             if zone_id is not None and raw_hour["Zone"] != zone_id:
                 usage = 0
             current_sum += usage


### PR DESCRIPTION
  - Short description:
      - guards Tauron energy parsing against None and empty values in both
        balance and statistics paths
      - prevents balance sensors from crashing when Tauron returns unmapped zone
        ids by falling back safely instead of raising KeyError
      - preserves zonesName across aggregated daily ranges so monthly and yearly
        balance attributes keep friendly tariff labels instead of raw ids like
        2_consumption
      - verified on the live Home Assistant instance: Tauron exceptions are gone
        and balance plus reading sensors are updating again