### PR TITLE
Handle null EC values in balanced data

### DIFF
--- a/custom_components/tauron_amiplus/sensor.py
+++ b/custom_components/tauron_amiplus/sensor.py
@@ -31,6 +31,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
+def _safe_float(value):
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     name = config.get(CONF_NAME)
     username = config.get(CONF_USERNAME)
@@ -248,11 +257,15 @@ class TauronAmiplusSensor(SensorEntity, CoordinatorEntity):
         sum_consumption = 0
         sum_generation = 0
         zones = {}
+        skipped_entries = 0
 
         for consumption, generation in zip(consumption_data, generation_data):
-            value_consumption = float(consumption["EC"])
-            value_generation = float(generation["EC"])
-            zone = zone_names[consumption["Zone"]]
+            value_consumption = _safe_float(consumption.get("EC"))
+            value_generation = _safe_float(generation.get("EC"))
+            if value_consumption is None or value_generation is None:
+                skipped_entries += 1
+                continue
+            zone = zone_names.get(consumption["Zone"], consumption["Zone"])
             balance = value_consumption - value_generation
             if balance > 0:
                 sum_consumption += balance
@@ -266,6 +279,9 @@ class TauronAmiplusSensor(SensorEntity, CoordinatorEntity):
                 if zone_key not in zones:
                     zones[zone_key] = 0
                 zones[zone_key] += balance
+
+        if skipped_entries > 0:
+            _LOGGER.debug("Skipped %s invalid balanced entries with missing EC value", skipped_entries)
 
         balance = sum_consumption + sum_generation
         return balance, sum_consumption, sum_generation, zones, data_range

--- a/custom_components/tauron_amiplus/statistics.py
+++ b/custom_components/tauron_amiplus/statistics.py
@@ -16,6 +16,15 @@ from .const import (CONF_METER_ID, CONF_METER_NAME, CONF_SHOW_BALANCED, CONF_SHO
 _LOGGER = logging.getLogger(__name__)
 
 
+def _safe_float(value):
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 class TauronAmiplusStatisticsUpdater:
 
     def __init__(self, hass: HomeAssistant, connector: TauronAmiplusConnector, meter_id: str, meter_name: str,
@@ -169,10 +178,14 @@ class TauronAmiplusStatisticsUpdater:
             return {}, {}
         balanced_consumption = []
         balanced_generation = []
+        skipped_entries = 0
 
         for consumption, generation in zip(consumption_data, generation_data):
-            value_consumption = float(consumption["EC"])
-            value_generation = float(generation["EC"])
+            value_consumption = _safe_float(consumption.get("EC"))
+            value_generation = _safe_float(generation.get("EC"))
+            if value_consumption is None or value_generation is None:
+                skipped_entries += 1
+                continue
             balance = value_consumption - value_generation
             if balance > 0:
                 output_consumption = {
@@ -203,6 +216,9 @@ class TauronAmiplusStatisticsUpdater:
             balanced_consumption.append(output_consumption)
             balanced_generation.append(output_generation)
 
+        if skipped_entries > 0:
+            _LOGGER.debug("Skipped %s invalid balanced statistics entries with missing EC value", skipped_entries)
+
         return balanced_consumption, balanced_generation
 
     async def update_stats(self, statistic_id, statistic_name, initial_sum, last_stats_time, zone_id, raw_data):
@@ -222,7 +238,10 @@ class TauronAmiplusStatisticsUpdater:
             start = self.get_time(raw_hour)
             if last_stats_time is not None and start <= last_stats_time:
                 continue
-            usage = float(raw_hour["EC"])
+            usage = _safe_float(raw_hour.get("EC"))
+            if usage is None:
+                self.log(f"Skipping statistics entry with invalid EC value: {raw_hour}")
+                continue
             if zone_id is not None and raw_hour["Zone"] != zone_id:
                 usage = 0
             current_sum += usage


### PR DESCRIPTION
Tauron API sometimes returns `EC: null` in balanced data.

This change prevents `TypeError` in sensor updates and statistics processing by skipping invalid entries with missing or non-numeric `EC` values.

It keeps the integration working when incomplete balanced data is returned by the API.